### PR TITLE
Add bitwarden entries with no folder to the "root" group

### DIFF
--- a/keepassxml.py
+++ b/keepassxml.py
@@ -25,13 +25,15 @@ def parse():
     j = read_bitwarden_json(filename)
 
     folders = parse_folders(j["folders"])
-    groups = {}
+    groups = {"root": {"Entry": []}}
     for folder in folders:
         group = folders[folder]
         groups[group] = create_kp_group(str(group).title())
 
     for item in j["items"]:
-        group = folders[item["folderId"]]
+        group = None
+        if item["folderId"]:
+            group = folders[item["folderId"]]
         title = item["name"]
         username = None
         password = None
@@ -63,17 +65,28 @@ def parse():
             else:
                 url = ""
 
-            groups[group]["Entry"].append(
-                get_kp_entry(
-                    title,
-                    username=username,
-                    password=password,
-                    url=url,
-                    otp=totp,
-                    notes="\n".join(notes),
+            if group:
+                groups[group]["Entry"].append(
+                    get_kp_entry(
+                        title,
+                        username=username,
+                        password=password,
+                        url=url,
+                        otp=totp,
+                        notes="\n".join(notes),
+                    )
                 )
-            )
-
+            else:
+                groups["root"]["Entry"].append(
+                    get_kp_entry(
+                        title,
+                        username=username,
+                        password=password,
+                        url=url,
+                        otp=totp,
+                        notes="\n".join(notes),
+                    )
+                )
     return groups.values()
 
 

--- a/keepassxml.py
+++ b/keepassxml.py
@@ -8,7 +8,8 @@ import json
 def parse_folders(bitwardenFolders):
     folders = {}
     for folder in bitwardenFolders:
-        folders[folder["id"]] = folder["name"]
+        if folder["id"]:
+            folders[folder["id"]] = folder["name"]
     return folders
 
 

--- a/keepassxml.py
+++ b/keepassxml.py
@@ -32,7 +32,7 @@ def parse():
         groups[group] = create_kp_group(str(group).title())
 
     for item in j["items"]:
-        group = None
+        group = "root"
         if item["folderId"]:
             group = folders[item["folderId"]]
         title = item["name"]
@@ -66,28 +66,16 @@ def parse():
             else:
                 url = ""
 
-            if group:
-                groups[group]["Entry"].append(
-                    get_kp_entry(
-                        title,
-                        username=username,
-                        password=password,
-                        url=url,
-                        otp=totp,
-                        notes="\n".join(notes),
-                    )
+            groups[group]["Entry"].append(
+                get_kp_entry(
+                    title,
+                    username=username,
+                    password=password,
+                    url=url,
+                    otp=totp,
+                    notes="\n".join(notes),
                 )
-            else:
-                groups["root"]["Entry"].append(
-                    get_kp_entry(
-                        title,
-                        username=username,
-                        password=password,
-                        url=url,
-                        otp=totp,
-                        notes="\n".join(notes),
-                    )
-                )
+            )
     return groups.values()
 
 


### PR DESCRIPTION
I don't have any folders in bitwarden so I got an exception when I tried to use this

--

Files changed looks more normal if you toggle Whitespace changes

<img width="240" alt="Screen Shot 2020-08-16 at 3 31 26 PM" src="https://user-images.githubusercontent.com/5882512/90343389-8f188b80-dfd5-11ea-9bb7-8730f851ea85.png">